### PR TITLE
Allow adding element-urns beside headers

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -91,3 +91,33 @@ body ::-webkit-scrollbar {
 body ::-webkit-scrollbar-thumb {
   background-color: var(--scrollbar-thumb-color);
 }
+
+div.sect2 h3 {
+  float: left;
+}
+
+div.sect2 div.element-urn {
+  float: right;
+  color: var(--toolbar-muted-color);
+  font-size: 0.75em;
+  text-align: right;
+}
+
+div.sect2 :not(div.element-urn) {
+  clear: both;
+}
+
+div.sect1 h2 {
+  float: left;
+  margin-bottom: 0.5em;
+}
+
+div.sect1 div.sectionbody div.element-urn {
+  float: right;
+  color: var(--toolbar-muted-color);
+  text-align: right;
+}
+
+div.sect1 div.sectionbody :not(div.element-urn) {
+  clear: both;
+}

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -29,6 +29,7 @@
   hyphens: none;
   line-height: 1.3;
   margin: 1rem 0 0;
+  clear: both;
 }
 
 .doc h1 {


### PR DESCRIPTION
Preparation for OpenManufacturingPlatform/sds-bamm-aspect-meta-model#116

This change will enable adding model URNs beside header like this:
![image](https://user-images.githubusercontent.com/1199036/160071575-eb2d5ccb-4ed3-4884-bb3b-a5fb3343373c.png)
